### PR TITLE
Fix patterns whose expected value starts with pattern

### DIFF
--- a/dict/web+db_press.yml
+++ b/dict/web+db_press.yml
@@ -251,7 +251,12 @@ rules:
     pattern: ツリー・エントリ
 
   - expected: ディレクター
-    pattern: ディレクタ
+    pattern: /ディレクタ(?!ー)/
+    specs:
+      - from: ディレクタ
+        to:   ディレクター
+      - from: ディレクター
+        to:   ディレクター
 
   - expected: データサービス
     pattern: /\bData Services\b/
@@ -408,7 +413,12 @@ rules:
     pattern: フィクスチャー
 
   - expected: フェイルオーバー
-    pattern: /フェイルオーバ|フェールオーバー|フェールオーバ/
+    pattern: /フェイルオーバ(?!ー)|フェールオーバー|フェールオーバ/
+    specs:
+      - from: フェイルオーバ
+        to:   フェイルオーバー
+      - from: フェイルオーバー
+        to:   フェイルオーバー
 
   - expected: フェーズ
     pattern: フェイズ
@@ -438,7 +448,12 @@ rules:
     pattern: プロバイダー
 
   - expected: ベンダー
-    pattern: ベンダ
+    pattern: /ベンダ(?!ー)/
+    specs:
+      - from: ベンダ
+        to:   ベンダー
+      - from: ベンダー
+        to:   ベンダー
 
   - expected: ヘッダ
     pattern: /ヘッダー|ヘッタ|ヘッター/
@@ -465,7 +480,12 @@ rules:
     pattern: マネージメント
 
   - expected: メーカー
-    pattern: メーカ
+    pattern: /メーカ(?!ー)/
+    specs:
+      - from: メーカ
+        to:   メーカー
+      - from: メーカー
+        to:   メーカー
 
   - expected: メーリングリスト
     pattern: /\bML\b/
@@ -648,7 +668,14 @@ rules:
     pattern: /\bDBFlute\b/i
 
   - expected: Debian GNU/Linux
-    pattern: /\bDebian\b|Debian\/GNU Linux/
+    pattern: /Debian\/GNU Linux|\bDebian(?! GNU\/Linux)\b/
+    specs:
+      - from: Debian
+        to:   Debian GNU/Linux
+      - from: Debian GNU/Linux
+        to:   Debian GNU/Linux
+      - from: Debian/GNU Linux
+        to:   Debian GNU/Linux
 
   # ☆dena.jp☆
   - expected: $1DeNA$2
@@ -1435,11 +1462,14 @@ rules:
 
   # 1本のダーシとケイをケイ2本に。★つまり─、★☆つまり──、☆
   - expected: $1──$2
-    pattern: /(?:([^―|─])―)|(?:―([^―|─]))/
-
-  # 1本のダーシとケイをケイ2本に。★つまり─、★☆つまり──、☆
-  - expected: $1──$2
-    pattern: /(?:([^―|─])─)|(?:─([^―|─]))/
+    pattern: /([^―─])[―─]([^―─])/
+    specs:
+      - from: つまり―、
+        to:   つまり──、
+      - from: つまり─、
+        to:   つまり──、
+      - from: つまり──、
+        to:   つまり──、
 
   - expected: "!?"
     pattern: ！？


### PR DESCRIPTION
This fix the `s/ベンダー/ベンダーー/` problem. See: https://github.com/azu/textlint-rule-prh/pull/8.

I've listed up patterns to be fixed with the following script `list-patterns-to-be-fixed.js`:

``` js
var prh = require('prh');
var engine = prh.fromYAMLFilePath('dict/web+db_press.yml');
var rules = engine.rules.filter(function(r) {
  return r.expected.match(r.pattern) && !(r.pattern.source.indexOf(r.expected) >= 0);
});
console.log(rules);
```

Before:

``` js
$ node list-patterns-to-be-fixed.js
[ Rule {
    expected: 'ディレクター',
    pattern: /ディレクタ/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw: { expected: 'ディレクター', pattern: 'ディレクタ' } },
  Rule {
    expected: 'フェイルオーバー',
    pattern: /フェイルオーバ|フェールオーバー|フェールオーバ/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw: { expected: 'フェイルオーバー', pattern: '/フェイルオーバ|フェールオーバー|フェールオーバ/' } },
  Rule {
    expected: 'ベンダー',
    pattern: /ベンダ/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw: { expected: 'ベンダー', pattern: 'ベンダ' } },
  Rule {
    expected: 'メーカー',
    pattern: /メーカ/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw: { expected: 'メーカー', pattern: 'メーカ' } },
  Rule {
    expected: 'Debian GNU/Linux',
    pattern: /\bDebian\b|Debian\/GNU Linux/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw:
     { expected: 'Debian GNU/Linux',
       pattern: '/\\bDebian\\b|Debian\\/GNU Linux/' } },
  Rule {
    expected: '$1──$2',
    pattern: /(?:([^―|─])─)|(?:─([^―|─]))/gm,
    regexpMustEmpty: undefined,
    options: Options { wordBoundary: false },
    specs: [],
    raw: { expected: '$1──$2', pattern: '/(?:([^―|─])─)|(?:─([^―|─]))/' } } ]
```

After:

``` js
$ node list-patterns-to-be-fixed.js
[]
```

Note: I've simplified the last pattern `s/([^―─])[―─]([^―─])/$1──$2/`.
